### PR TITLE
"Full" Site Layout Skeleton/Foundation

### DIFF
--- a/frontend-site/src/components/Home/UtilitiesListing.vue
+++ b/frontend-site/src/components/Home/UtilitiesListing.vue
@@ -6,9 +6,13 @@
       :key="i">
       <!-- TODO: move into another separate component or keep inline here? -->
       <v-card class="utility-card">
-        <v-card-title>
-          <h1 class="title">{{ utility }}</h1>
-        </v-card-title>
+        <v-container fluid>
+          <v-layout align-center align-content-center>
+            <v-flex class="text-xs-center">
+              <h1 class="title">{{ utility }}</h1>
+            </v-flex>
+          </v-layout>
+        </v-container>
       </v-card>
     </v-flex>
   </v-layout>

--- a/frontend-site/src/components/Home/UtilitiesListing.vue
+++ b/frontend-site/src/components/Home/UtilitiesListing.vue
@@ -19,17 +19,10 @@
 </template>
 
 <script>
+import { utilitiesOffered } from '@/modules/staticData';
 export default {
   computed: {
-    utilities () {
-      console.warn('using mock utilities data');
-      return [
-        'Raspberry Pi',
-        'Arduino',
-        'Ice Cream',
-        '3-D Printing',
-      ];
-    },
+    utilities: () => utilitiesOffered,
   },
 };
 </script>

--- a/frontend-site/src/components/MainNavigationDrawer.vue
+++ b/frontend-site/src/components/MainNavigationDrawer.vue
@@ -18,7 +18,7 @@
           <!-- list of site links -->
           <v-list>
             <template v-for="(item, i) in pages">
-              <v-list-tile v-if="item.to" :key="i" :to="item.to">
+              <v-list-tile v-if="item.to || item.href" :key="i" :to="item.to" :href="item.href">
                 <v-list-tile-content>
                   <v-list-tile-title>{{ item.name }}</v-list-tile-title>
                 </v-list-tile-content>
@@ -29,7 +29,7 @@
                     <v-list-tile-title>{{ item.name }}</v-list-tile-title>
                   </v-list-tile-content>
                 </v-list-tile>
-                <v-list-tile v-for="(subItem, j) in item.sublinks" :key="j" :to="subItem.to">
+                <v-list-tile v-for="(subItem, j) in item.sublinks" :key="j" :to="subItem.to" :href="subItem.href">
                   <v-list-tile-content>
                     <v-list-tile-title>{{ subItem.name }}</v-list-tile-title>
                   </v-list-tile-content>
@@ -65,7 +65,9 @@ export default {
           },
           {
             name: 'Wiki',
-            to: '/wiki',
+            // TODO: eventually delete wiki page component
+            // to: '/wiki',
+            href: 'https://lug.cs.uic.edu/wiki/doku.php?id=start',
           },
         ],
       },

--- a/frontend-site/src/modules/mockData.js
+++ b/frontend-site/src/modules/mockData.js
@@ -32,7 +32,8 @@ export const mockOfficers = Object.freeze([
   },
 ]);
 
-export const mockEvents = Object.freeze([{
+export const mockEvents = Object.freeze([
+  {
     "summary": "/bin/systemctl: Virtual Machines",
     "timeStart": "2018-10-22T22:00:00.000Z",
     "timeEnd": "2018-10-22T23:00:00.000Z",
@@ -207,4 +208,27 @@ export const mockEvents = Object.freeze([{
     "location": "",
     "description": ""
   }
+]);
+
+export const mockProjects = Object.freeze([
+  // TODO: finalize project structure
+  {
+    name: 'Project Name',
+    status: 'incomplete', // use enums/predefined keys?
+    description: 'project description',
+    smallImage: 'link to small image',
+    largeImage: 'link to large image',
+    wikiLink: 'link to wiki for this project',
+    githubLink: 'link to github for this project',
+  },
+]);
+
+export const mockServices = Object.freeze([
+  // TODO: finalize service structure
+  {
+    name: 'Service Name',
+    image: 'link to service image',
+    description: 'description of service',
+    url: 'url for service, if any',
+  },
 ]);

--- a/frontend-site/src/modules/mockData.js
+++ b/frontend-site/src/modules/mockData.js
@@ -220,7 +220,9 @@ export const mockProjects = Object.freeze([
     largeImage: 'link to large image',
     wikiLink: 'link to wiki for this project',
     githubLink: 'link to github for this project',
+    startDate: new Date(),
   },
+  // TODO: add mock data for website redesign project
 ]);
 
 export const mockServices = Object.freeze([

--- a/frontend-site/src/modules/staticData.js
+++ b/frontend-site/src/modules/staticData.js
@@ -1,0 +1,29 @@
+// TODO: decide what stays here and what can be stored as a JSON file for the API to send
+export const utilitiesOffered = Object.freeze([
+  'Raspberry Pi',
+  'Arduino',
+  'Ice Cream',
+  '3-D Printing',
+]);
+
+export const servicesOffered = Object.freeze([
+  // TODO: fill in empty entries
+  {
+    name: 'Raspberry Pi',
+    image: '',
+    description: '',
+    url: '',
+  },
+  {
+    name: 'Arduino',
+    image: '',
+    description: '',
+    url: '',
+  },
+  {
+    name: '3D Printing',
+    image: '',
+    description: '',
+    url: 'https://lug.cs.uic.edu/3dprint/home',
+  },
+])

--- a/frontend-site/src/views/About.vue
+++ b/frontend-site/src/views/About.vue
@@ -1,3 +1,48 @@
 <template>
-  <h1>This is the about page</h1>
+  <v-container grid-list-lg>
+    <v-layout>
+      <v-flex>
+        <v-card>
+          <v-card-title primary-title>
+            <h1 class="title">Who We Are</h1>
+          </v-card-title>
+          <v-card-text>
+            who we are goes here.
+          </v-card-text>
+          <v-card-actions>
+            <v-btn flat>Constitution</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-flex>
+    </v-layout>
+    <v-layout>
+      <v-flex>
+        <v-card>
+          <v-card-title primary-title>
+            <h1 class="title">What We Do</h1>
+          </v-card-title>
+          <v-card-text>
+            What We Do goes here.
+          </v-card-text>
+        </v-card>
+      </v-flex>
+    </v-layout>
+    <v-layout>
+      <v-flex>
+        <v-card>
+          <v-card-title primary-title>
+            <h1 class="title">Where Are We</h1>
+          </v-card-title>
+          <v-card-text>
+            info about office location, social links (slack, github, etc.) goes here.
+          </v-card-text>
+        </v-card>
+      </v-flex>
+    </v-layout>
+    <v-layout>
+      <v-flex>
+        listing of previous officers by semester goes here; potentially reuse officer listing component
+      </v-flex>
+    </v-layout>
+  </v-container>
 </template>

--- a/frontend-site/src/views/Projects.vue
+++ b/frontend-site/src/views/Projects.vue
@@ -1,3 +1,96 @@
 <template>
-  <h1>This is the project listing page</h1>
+  <v-container grid-list-lg>
+    <v-layout row>
+      <v-flex>
+        <v-card>
+          Search area here?
+        </v-card>
+      </v-flex>
+    </v-layout>
+    <v-layout row wrap>
+      <v-flex
+        v-for="(project, i) in projects"
+        :key="i"
+        xs12 md6 lg3>
+        <!-- TODO: refactor into separate component -->
+        <v-card @click.native="activeProject = project" class="project-card">
+          <!-- would put v-img or other image element here -->
+          <v-container style="border: 1px solid white;">
+            {{ project.smallImage }}
+          </v-container>
+          <v-card-title primary-title>
+            <h1 class="headline">{{ project.name }}</h1>
+          </v-card-title>
+          <v-card-text class="text-xs-right pt-0">
+            <h2 class="subheading">{{ project.status.toUpperCase() }}</h2>
+          </v-card-text>
+        </v-card>
+      </v-flex>
+    </v-layout>
+    <v-dialog v-model="showModal">
+      <v-card v-if="activeProject">
+        <v-card-text>
+          <v-container fluid>
+            <v-layout row wrap>
+              <v-flex xs12 md7>
+                {{ activeProject.largeImage }}
+              </v-flex>
+              <v-flex xs12 md5>
+                <h1 class="title">{{ activeProject.name }}</h1>
+                <p>{{ activeProject.description }}</p>
+              </v-flex>
+            </v-layout>
+          </v-container>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer/>
+          <v-btn flat>GitHub</v-btn>
+          <v-btn flat>Wiki</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
 </template>
+
+<script>
+import { mockProjects } from '@/modules/mockData';
+
+export default {
+  computed: {
+    projects: () => new Array(12).fill(mockProjects[0]),
+  },
+  data () {
+    return {
+      activeProject: null,
+      showModal: false,
+    };
+  },
+  mounted () {
+    console.warn('using mock data for projects');
+  },
+  watch: {
+    activeProject (newValue) {
+      console.debug(newValue);
+      if (newValue) {
+        this.showModal = true;
+      }
+    },
+    showModal (newValue) {
+      if (!newValue) {
+        this.activeProject = null;
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.project-card {
+  cursor: pointer;
+  & > * {
+    pointer-events: none;
+  }
+}
+</style>
+
+

--- a/frontend-site/src/views/Services.vue
+++ b/frontend-site/src/views/Services.vue
@@ -2,18 +2,23 @@
   <v-container grid-list-lg>
     <v-layout row wrap>
       <v-flex xs12 sm6 md4 v-for="(service, i) in services" :key="i">
-        <!-- TODO: refactor into exparate component -->
+        <!-- TODO: refactor separate component? -->
         <v-card class="ma-2">
           <v-container fluid class="pa-0">
             <v-layout row>
               <v-flex xs5>
                 <div style="border: 1px solid white; height: 100%;">
-                  {{ service.image }}
+                  <!-- TODO: turn into image/svg tag -->
+                  {{ service.image || 'No image specified' }}
                 </div>
               </v-flex>
-              <v-flex xs7>
+              <v-flex xs7 class="pr-3">
                 <h1 class="title">{{ service.name }}</h1>
-                <p>{{ service.description }}</p>
+                <p>{{ service.description || 'No description specified' }}</p>
+                <v-card-actions v-if="service.url">
+                  <v-spacer/>
+                  <v-btn flat :href="service.url">More Info</v-btn>
+                </v-card-actions>
               </v-flex>
             </v-layout>
           </v-container>
@@ -24,13 +29,10 @@
 </template>
 
 <script>
-import { mockServices } from '@/modules/mockData';
+import { servicesOffered } from '@/modules/staticData';
 export default {
   computed: {
-    services: () => new Array(12).fill(mockServices[0]),
-  },
-  mounted () {
-    console.warn('using mock data for services');
+    services: () => servicesOffered,
   },
 };
 </script>

--- a/frontend-site/src/views/Services.vue
+++ b/frontend-site/src/views/Services.vue
@@ -1,32 +1,19 @@
 <template>
   <v-container grid-list-lg>
     <v-layout row wrap>
-      <v-flex xs12 v-for="(service, i) in services" :key="i">
+      <v-flex xs12 sm6 md4 v-for="(service, i) in services" :key="i">
         <!-- TODO: refactor into exparate component -->
         <v-card class="ma-2">
           <v-container fluid class="pa-0">
             <v-layout row>
-              <v-flex xs6>
-                <template v-if="i % 2 === 0">
-                  <div style="border: 1px solid white; height: 100%;">
-                    {{ service.image }}
-                  </div>
-                </template>
-                <template v-else>
-                  <h1 class="title">{{ service.name }}</h1>
-                  <p>{{ service.description }}</p>
-                </template>
+              <v-flex xs5>
+                <div style="border: 1px solid white; height: 100%;">
+                  {{ service.image }}
+                </div>
               </v-flex>
-              <v-flex xs6>
-                <template v-if="i % 2 === 1">
-                  <div style="border: 1px solid white; height: 100%;">
-                    {{ service.image }}
-                  </div>
-                </template>
-                <template v-else>
-                  <h1 class="title">{{ service.name }}</h1>
-                  <p>{{ service.description }}</p>
-                </template>
+              <v-flex xs7>
+                <h1 class="title">{{ service.name }}</h1>
+                <p>{{ service.description }}</p>
               </v-flex>
             </v-layout>
           </v-container>

--- a/frontend-site/src/views/Services.vue
+++ b/frontend-site/src/views/Services.vue
@@ -1,3 +1,49 @@
 <template>
-  <h1>This is the services page</h1>
+  <v-container grid-list-lg>
+    <v-layout row wrap>
+      <v-flex xs12 v-for="(service, i) in services" :key="i">
+        <!-- TODO: refactor into exparate component -->
+        <v-card class="ma-2">
+          <v-container fluid class="pa-0">
+            <v-layout row>
+              <v-flex xs6>
+                <template v-if="i % 2 === 0">
+                  <div style="border: 1px solid white; height: 100%;">
+                    {{ service.image }}
+                  </div>
+                </template>
+                <template v-else>
+                  <h1 class="title">{{ service.name }}</h1>
+                  <p>{{ service.description }}</p>
+                </template>
+              </v-flex>
+              <v-flex xs6>
+                <template v-if="i % 2 === 1">
+                  <div style="border: 1px solid white; height: 100%;">
+                    {{ service.image }}
+                  </div>
+                </template>
+                <template v-else>
+                  <h1 class="title">{{ service.name }}</h1>
+                  <p>{{ service.description }}</p>
+                </template>
+              </v-flex>
+            </v-layout>
+          </v-container>
+        </v-card>
+      </v-flex>
+    </v-layout>
+  </v-container>
 </template>
+
+<script>
+import { mockServices } from '@/modules/mockData';
+export default {
+  computed: {
+    services: () => new Array(12).fill(mockServices[0]),
+  },
+  mounted () {
+    console.warn('using mock data for services');
+  },
+};
+</script>


### PR DESCRIPTION
Contains layouts generated from mockups provided by @Benbigmac as well as content based on previous meeting discussions. The status (and an image) of each page is as follows with this PR.

* [Home](https://i.imgur.com/zvbi3tg.png): Nearly finished in terms of front-end. Just missing some card implementations and testing for backend queries
* [Project Listing](https://i.imgur.com/0KlW9s1.png): A mock layout exists. Need to implement a search/sort area as well as potentially adding API support for projects. Also need to clean up the styling/properly implement the project cards. Clicking a project opens a skeleton project modal, which may need some styling work.
* Wiki: Now redirects to the [LUG wiki page](https://lug.cs.uic.edu/wiki/doku.php?id=start).
* Events: No work done on it with this PR, but current plans are to make it look similar to the events page from the CS lounge, which uses [this project](https://github.com/bmiddha/cs-lounge-display)
* [Services](https://i.imgur.com/E5Mxo8i.png): There is a listing of services available, but much styling needs to be done. Also need to consider what other services to add here.
* [About](https://i.imgur.com/b1xmVXW.png): Added a layout for areas to be filled in. Hardest part about this may be the officer listing.

* Other things
  * Need to figure out what can be a JSON file served by the server or simply a hard-coded thing on the website itself (such as utilities, services)
  * issues/tickets for other pages will start popping up once this PR is approved