### PR TITLE
Officers API and data

### DIFF
--- a/officers.json
+++ b/officers.json
@@ -9,13 +9,13 @@
     "image": "",
     "special_ability": "Heelys",
     "join_date": "",
-    "current_student": true,
     "term_start": "SUMMER_2018",
-    "term_end": "SPRING_2019"
+    "term_end": "SPRING_2019",
+    "graduating_semester": "SPRING_2019"
   },
   {
     "name": "Bharat Middha",
-    "position": "VICEPRESIDENT",
+    "position": "VICE_PRESIDENT",
     "description": "Fix it, sysadmin",
     "github": "bmiddha",
     "slack": "bharat",
@@ -23,9 +23,9 @@
     "image": "",
     "special_ability": "Arch",
     "join_date": "",
-    "current_student": true,
     "term_start": "SUMMER_2018",
-    "term_end": "SPRING_2019"
+    "term_end": "SPRING_2019",
+    "graduating_semester": "SPRING_2021"
   },
   {
     "name": "Joey Voorhees",
@@ -37,9 +37,9 @@
     "image": "",
     "special_ability": "Memes",
     "join_date": "",
-    "current_student": true,
     "term_start": "SUMMER_2018",
-    "term_end": "SPRING_2019"
+    "term_end": "SPRING_2019",
+    "graduating_semester": "SPRING_2021"
   },
   {
     "name": "Alex Matache",
@@ -51,9 +51,9 @@
     "image": "",
     "special_ability": "",
     "join_date": "",
-    "current_student": true,
     "term_start": "SUMMER_2017",
-    "term_end": "SPRING_2018"
+    "term_end": "SPRING_2018",
+    "graduating_semester": "FALL_2018"
   },
   {
     "name": "Kevin Liu",
@@ -65,8 +65,8 @@
     "image": "",
     "special_ability": "invisibility",
     "join_date": "",
-    "current_student": false,
     "term_start": "SUMMER_2017",
-    "term_end": "FALL_2017"
+    "term_end": "FALL_2017",
+    "graduating_semester": "SPRING_2018"
   }
 ]

--- a/officers.json
+++ b/officers.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "Ben Maciorowski",
+    "position": "PRESIDENT",
+    "description": "Constantly dying",
+    "github": "",
+    "slack": "benbigmac",
+    "personal_site": "",
+    "image": "",
+    "special_ability": "Heelys",
+    "join_date": "",
+    "current_student": true,
+    "term_start": "SUMMER_2018",
+    "term_end": "SPRING_2019"
+  },
+  {
+    "name": "Bharat Middha",
+    "position": "VICEPRESIDENT",
+    "description": "Fix it, sysadmin",
+    "github": "bmiddha",
+    "slack": "bharat",
+    "personal_site": "",
+    "image": "",
+    "special_ability": "Arch",
+    "join_date": "",
+    "current_student": true,
+    "term_start": "SUMMER_2018",
+    "term_end": "SPRING_2019"
+  },
+  {
+    "name": "Joey Voorhees",
+    "position": "TREASURER",
+    "description": "Lactose intolerant",
+    "github": "",
+    "slack": "apollo",
+    "personal_site": "",
+    "image": "",
+    "special_ability": "Memes",
+    "join_date": "",
+    "current_student": true,
+    "term_start": "SUMMER_2018",
+    "term_end": "SPRING_2019"
+  },
+  {
+    "name": "Alex Matache",
+    "position": "PRESIDENT",
+    "description": "Constantly dying inside",
+    "github": "",
+    "slack": "alexmatache",
+    "personal_site": "",
+    "image": "",
+    "special_ability": "",
+    "join_date": "",
+    "current_student": true,
+    "term_start": "SUMMER_2017",
+    "term_end": "SPRING_2018"
+  },
+  {
+    "name": "Kevin Liu",
+    "position": "TREASURER",
+    "description": "Dapper dresser",
+    "github": "",
+    "slack": "",
+    "personal_site": "",
+    "image": "",
+    "special_ability": "invisibility",
+    "join_date": "",
+    "current_student": false,
+    "term_start": "SUMMER_2017",
+    "term_end": "FALL_2017"
+  }
+]

--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ class Positions(Enum):
   List of LUG Officer positions.
   """
   PRESIDENT = "PRESIDENT"
-  VICEPRESIDENT = "VICEPRESIDENT"
+  VICE_PRESIDENT = "VICE_PRESIDENT"
   TREASURER = "TREASURER"
   MEMBER = "MEMBER"
 
@@ -62,98 +62,151 @@ def getPosts():
   ]
   return jsonify(posts)
 
+def getSemesterID(semester_string):
+  """
+  Convert a semester string of the form "SEASON_YEAR" (e.g. "SPRING_2018") into
+  a numeric value
+  Works by left-shifting the year by 2 and adding a value for the season - fast,
+  preserves ordering; can easily get season by testing modulo the season (e.g.
+  if id % 4 == 1, season is Summer)
+  """
+  season, year_str = semester_string.strip().upper().split('_')
+  if season == 'SPRING':
+    season_id = 0
+  elif season == 'SUMMER':
+    season_id = 1
+  elif season == 'FALL':
+    season_id = 2
+  else: # Probably an error
+    season_id = 3
+  semester_id = (int(year_str) << 2) + season_id
+  return semester_id
+
+def getSemesterString(semester_id):
+  """
+  Convert numeric semester_id into human-readable string
+  """
+  year = semester_id >> 2
+  season_id = semester_id % 4
+  if season_id == 0:
+    return "SPRING_" + year
+  if season_id == 1:
+    return "SUMMER_" + year
+  if season_id == 2:
+    return "FALL_" + year
+  return "UNKNOWN_" + year
+
 @app.route('/api/officers', methods=['GET'])
 def getOfficers():
   """
   API function to retrieve officers
   Parameters:
-  /api/officers?position=[PRESIDENT,VICEPRESIDENT,TREASURER]
+  /api/officers?position=[PRESIDENT,VICE_PRESIDENT,TREASURER]
                ?semester=SEASON_YEAR
                   e.g. "?semester=SUMMER_2018
                   Overrides 'year'
                ?year=<Academic year>
                   e.g. "?year=2018" for Summer 2018 - Spring 2019 inclusive
                   Not read if 'semester' param exists
-               ?is_current=[Y,N]
+               ?is_current_student=[Y,N] - TODO
   """
 
-  # Utility functions
+  class Officer():
+    """
+    Represents Officer objects from the json file
+    Used by json.load() - see 'object_hook' in the Python docs
+    """
+    def __init__(self, d):
+      # d is the dictionary passed by json.load()
+      self.name = str(d['name'])
+      self.position = d['position']
+      self.description = str(d['description'])
+      self.github = d['github']
+      self.slack = str(d['slack'])
+      self.personal_site = d['personal_site']
+      self.image = d['image']
+      self.special_ability = str(d['special_ability'])
+      self.join_date = d['join_date']
+      self.term_start = d['term_start']
+      self.term_end = d['term_end']
+      self.graduating_semester = d['graduating_semester']
 
-  def getSemesterID(semester_string):
-    """
-    Convert a semester string of the form "SEASON_YEAR" (e.g. "SPRING_2018") into
-    a numeric value
-    Works by left-shifting the year by 2 and adding a value for the season - fast,
-    preserves ordering; can easily get season by testing modulo the season (e.g.
-    if id % 4 == 1, season is Summer)
-    """
-    season, year_str = semester_string.strip().upper().split('_')
-    if season == 'SPRING':
-      season_id = 0
-    elif season == 'SUMMER':
-      season_id = 1
-    elif season == 'FALL':
-      season_id = 2
-    else: # Probably an error
-      season_id = 3
-    semester_id = (int(year_str) << 2) + season_id
-    return semester_id
+    def term_start_id(self):
+      """
+      Convert term_start semester string to numeric ID
+      """
+      return getSemesterID(self.term_start)
 
-  def getSemesterString(semester_id):
-    """
-    Convert numeric semester_id into human-readable string
-    """
-    year = semester_id >> 2
-    season_id = semester_id % 4
-    if season_id == 0:
-      return "SPRING_" + year
-    if season_id == 1:
-      return "SUMMER_" + year
-    if season_id == 2:
-      return "FALL_" + year
-    return "UNKNOWN_" + year
+    def term_end_id(self):
+      """
+      Convert term_end semester string to numeric ID
+      """
+      return getSemesterID(self.term_end)
 
-  def upperStr(reqstr):
-    """
-    Utility function to convert input to uppercase string
-    """
-    return str(reqstr).upper()
+    def served_during_semester(self, semester_id):
+      """
+      Return True if this officer's term of office includes the given numeric
+      semester ID, False otherwise
+      """
+      return self.term_start_id() <= semester_id <= self.term_end_id()
 
-  def semesterStr(reqstr):
+    def served_during_year(self, year):
+      """
+      Return True if this officer served during the given academic year, defined
+      as Summer [year] to Spring [year + 1]; False otherwise
+      """
+      range_start_id = getSemesterID(f'SUMMER_{year}')
+      range_end_id = getSemesterID(f'SPRING_{(year + 1)}')
+      return self.term_start_id() < range_end_id and self.term_end_id() > range_start_id
+
+    def is_current_student(self):
+      # TODO
+      pass
+
+  class OfficersParams(Enum):
     """
-    Returns None if str is not a semester string, and converts it to standard
-    format if it is (TODO)
+    List of /api/officers query parameters
+    """
+    POSITION = 'position'
+    SEMESTER = 'semester'
+    YEAR = 'year'
+    IS_CURRENT_STUDENT = 'is_current_student'
+
+  def semesterIDType(reqstr):
+    """
+    Returns None if reqstr is not a semester string, and converts it to standard
+    format if it is.
     Standard format is SEASON_YEAR, e.g. SPRING_2018
+    TODO: accept more formats
     """
     template = re.compile(r'(SPRING|SUMMER|FALL)_\d\d\d\d')
     reqstr = str(reqstr).upper()
     if template.match(reqstr):
-      return reqstr
+      return getSemesterID(reqstr)
     return None
 
   # Get officers from json file
   with open('officers.json') as officers_file:
-    officers = json.load(officers_file)
+    officers = json.load(officers_file, object_hook=Officer)
 
   # Filter by position (President etc.)
-  position = request.args.get('position', default=None, type=upperStr)
+  position = request.args.get(OfficersParams.POSITION.value, default=None,
+                              type=(lambda x: str(x).upper()))
   if position:
     # If invalid position given, error
     if position not in Positions.__members__:
       return jsonify({"error": "Invalid parameter 'position'"}), 400
-    officers = [x for x in officers if x["position"] == position]
+    officers = [x for x in officers if x.position == position]
 
   # Filter by semester
-  semester = request.args.get('semester', default=None, type=semesterStr)
-  year = request.args.get('year', default=None, type=int)
+  semester = request.args.get(OfficersParams.SEMESTER.value,
+                              default=None,
+                              type=semesterIDType)
+  year = request.args.get(OfficersParams.YEAR.value, default=None, type=int)
+
   if semester:
-    sem_id = getSemesterID(semester)
-    def semesterInRange(officer):
-      term_start_id = getSemesterID(officer["term_start"])
-      term_end_id = getSemesterID(officer["term_end"])
-      return term_start_id <= sem_id <= term_end_id
-    officers = [x for x in officers if semesterInRange(x)]
-  elif not semester and 'semester' in request.args:
+    officers = [x for x in officers if x.served_during_semester(semester)]
+  elif not semester and OfficersParams.SEMESTER.value in request.args:
     # In this case, a semester parameter was passed but semesterStr failed to
     # match
     return jsonify({"error": "Invalid parameter 'semester'"}), 400
@@ -161,22 +214,17 @@ def getOfficers():
     # Filter by term academic year - semester param overrides this
     # We want all officers whose term began before the end, and ended after the
     # beginning, of this academic year.
-    range_start_id = getSemesterID(f'SUMMER_{year}')
-    range_end_id = getSemesterID(f'SPRING_{(year + 1)}')
-    def yearInRange(officer):
-      term_start_id = getSemesterID(officer["term_start"])
-      term_end_id = getSemesterID(officer["term_end"])
-      return term_start_id < range_end_id and term_end_id > range_start_id
-    officers = [x for x in officers if yearInRange(x)]
+    officers = [x for x in officers if x.served_during_year(year)]
 
-  # Filter by current student status
-  if 'is_current' in request.args:
-    is_current_char = request.args.get('is_current', type=upperStr)
-    if is_current_char in ('Y', 'T', 'YES', 'TRUE'):
-      officers = [x for x in officers if x["current_student"]]
-    elif is_current_char in ('N', 'F', 'NO', 'FALSE'):
-      officers = [x for x in officers if not x["current_student"]]
-    else:
-      return jsonify({"error": "Invalid parameter 'is_current'"}), 400
+  # TODO: Filter by current student status
+  # if OfficersParams.IS_CURRENT_STUDENT.value in request.args:
+  #   is_current_char = request.args.get(OfficersParams.IS_CURRENT_STUDENT.value, type=upperStr)
+  #   if is_current_char in ('Y', 'T', 'YES', 'TRUE'):
+  #     pass
+  #   elif is_current_char in ('N', 'F', 'NO', 'FALSE'):
+  #     pass
+  #   else:
+  #     return jsonify({"error": "Invalid parameter 'is_current'"}), 400
 
-  return jsonify(officers)
+  # Convert Officer objects back to dictionaries before returning
+  return jsonify([x.__dict__ for x in officers])

--- a/server.py
+++ b/server.py
@@ -1,8 +1,20 @@
 """
 Backend server for LUG@UIC website
 """
-from flask import Flask, jsonify
+from enum import Enum
+import json
+import re
+from flask import Flask, jsonify, request
 from flask_cors import CORS
+
+class Positions(Enum):
+  """
+  List of LUG Officer positions.
+  """
+  PRESIDENT = "PRESIDENT"
+  VICEPRESIDENT = "VICEPRESIDENT"
+  TREASURER = "TREASURER"
+  MEMBER = "MEMBER"
 
 app = Flask(__name__, static_url_path='/static/', static_folder='frontend-site/dist')
 
@@ -50,3 +62,121 @@ def getPosts():
   ]
   return jsonify(posts)
 
+@app.route('/api/officers', methods=['GET'])
+def getOfficers():
+  """
+  API function to retrieve officers
+  Parameters:
+  /api/officers?position=[PRESIDENT,VICEPRESIDENT,TREASURER]
+               ?semester=SEASON_YEAR
+                  e.g. "?semester=SUMMER_2018
+                  Overrides 'year'
+               ?year=<Academic year>
+                  e.g. "?year=2018" for Summer 2018 - Spring 2019 inclusive
+                  Not read if 'semester' param exists
+               ?is_current=[Y,N]
+  """
+
+  # Utility functions
+
+  def getSemesterID(semester_string):
+    """
+    Convert a semester string of the form "SEASON_YEAR" (e.g. "SPRING_2018") into
+    a numeric value
+    Works by left-shifting the year by 2 and adding a value for the season - fast,
+    preserves ordering; can easily get season by testing modulo the season (e.g.
+    if id % 4 == 1, season is Summer)
+    """
+    season, year_str = semester_string.strip().upper().split('_')
+    if season == 'SPRING':
+      season_id = 0
+    elif season == 'SUMMER':
+      season_id = 1
+    elif season == 'FALL':
+      season_id = 2
+    else: # Probably an error
+      season_id = 3
+    semester_id = (int(year_str) << 2) + season_id
+    return semester_id
+
+  def getSemesterString(semester_id):
+    """
+    Convert numeric semester_id into human-readable string
+    """
+    year = semester_id >> 2
+    season_id = semester_id % 4
+    if season_id == 0:
+      return "SPRING_" + year
+    if season_id == 1:
+      return "SUMMER_" + year
+    if season_id == 2:
+      return "FALL_" + year
+    return "UNKNOWN_" + year
+
+  def upperStr(reqstr):
+    """
+    Utility function to convert input to uppercase string
+    """
+    return str(reqstr).upper()
+
+  def semesterStr(reqstr):
+    """
+    Returns None if str is not a semester string, and converts it to standard
+    format if it is (TODO)
+    Standard format is SEASON_YEAR, e.g. SPRING_2018
+    """
+    template = re.compile(r'(SPRING|SUMMER|FALL)_\d\d\d\d')
+    reqstr = str(reqstr).upper()
+    if template.match(reqstr):
+      return reqstr
+    return None
+
+  # Get officers from json file
+  with open('officers.json') as officers_file:
+    officers = json.load(officers_file)
+
+  # Filter by position (President etc.)
+  position = request.args.get('position', default=None, type=upperStr)
+  if position:
+    # If invalid position given, error
+    if position not in Positions.__members__:
+      return jsonify({"error": "Invalid parameter 'position'"}), 400
+    officers = [x for x in officers if x["position"] == position]
+
+  # Filter by semester
+  semester = request.args.get('semester', default=None, type=semesterStr)
+  year = request.args.get('year', default=None, type=int)
+  if semester:
+    sem_id = getSemesterID(semester)
+    def semesterInRange(officer):
+      term_start_id = getSemesterID(officer["term_start"])
+      term_end_id = getSemesterID(officer["term_end"])
+      return term_start_id <= sem_id <= term_end_id
+    officers = [x for x in officers if semesterInRange(x)]
+  elif not semester and 'semester' in request.args:
+    # In this case, a semester parameter was passed but semesterStr failed to
+    # match
+    return jsonify({"error": "Invalid parameter 'semester'"}), 400
+  elif year:
+    # Filter by term academic year - semester param overrides this
+    # We want all officers whose term began before the end, and ended after the
+    # beginning, of this academic year.
+    range_start_id = getSemesterID(f'SUMMER_{year}')
+    range_end_id = getSemesterID(f'SPRING_{(year + 1)}')
+    def yearInRange(officer):
+      term_start_id = getSemesterID(officer["term_start"])
+      term_end_id = getSemesterID(officer["term_end"])
+      return term_start_id < range_end_id and term_end_id > range_start_id
+    officers = [x for x in officers if yearInRange(x)]
+
+  # Filter by current student status
+  if 'is_current' in request.args:
+    is_current_char = request.args.get('is_current', type=upperStr)
+    if is_current_char in ('Y', 'T', 'YES', 'TRUE'):
+      officers = [x for x in officers if x["current_student"]]
+    elif is_current_char in ('N', 'F', 'NO', 'FALSE'):
+      officers = [x for x in officers if not x["current_student"]]
+    else:
+      return jsonify({"error": "Invalid parameter 'is_current'"}), 400
+
+  return jsonify(officers)


### PR DESCRIPTION
Implements #12.
Note that this implementation differs from #11 in the following ways:
* I really don't like "rank", it feels too hierarchical for LUG. I've used "position" instead throughout. I can change this back if it'll be too much of a hassle to change everything else.
* `Officer` objects now have the additional members `term_start` and `term_end`, representing the start and end of their term of office. For a normal term of office, these run from Summer of one calendar year to Spring of the next, inclusive. These are stored in the form `SEASON_YYYY`, e.g. `SPRING_2018`.
* The route `/api/officers` provides the following query parameters:
```
  /api/officers?position=[PRESIDENT,VICEPRESIDENT,TREASURER]
                  Officers holding the given position
               ?semester=SEASON_YEAR
                  Officer was in office during the given semester
                  e.g. "?semester=SUMMER_2018
                  Overrides 'year'
               ?year=<Academic year>
                  Officer was in office during the given calendar year
                  Note that, as some officers do not serve a full calendar year, this may
                  return multiple individuals for a position
                  e.g. "?year=2018" for Summer 2018 - Spring 2019 inclusive
                  Not read if 'semester' param exists
               ?is_current=[Y,N]
                  Return only current students
```
(Now I look at it, `is_current` is confusing, people might think it means "is currently serving" rather than "is currently a student".)

Coming out of this, I'd like to get proper logging and testing set up, those would've been helpful when developing this. I'll make issues for those.