### PR TITLE
Feature about page text

### DIFF
--- a/frontend-site/src/views/About.vue
+++ b/frontend-site/src/views/About.vue
@@ -29,7 +29,8 @@
             <h1 class="title">What We Do</h1>
           </v-card-title>
           <v-card-text>
-            What We Do goes here.
+            As an organization we provide support for students who are interested in learning about Linux and the open source community.
+            Our goal is to spread open source technology and grow as programmers and individuals and eventually be able to contribute to the open source community.
           </v-card-text>
         </v-card>
       </v-flex>
@@ -41,8 +42,18 @@
             <h1 class="title">Where Are We</h1>
           </v-card-title>
           <v-card-text>
-            info about office location, social links (slack, github, etc.) goes here.
+            LUG shares an office with the UIC ACM in SELE 2264. Meetings are in SELE 2260 unless otherwise announced.
           </v-card-text>
+          <v-card-actions>
+            <v-btn flat target="_blank" href="https://lugatuic.slack.com/messages" rel="noopener">
+              <v-icon left>fab fa-slack</v-icon>
+              Slack
+            </v-btn>
+            <v-btn flat target="_blank" href="https://github.com/lugatuic" rel="noopener">
+              <v-icon left>fab fa-github</v-icon>
+              Github
+            </v-btn>
+          </v-card-actions>
         </v-card>
       </v-flex>
     </v-layout>

--- a/frontend-site/src/views/About.vue
+++ b/frontend-site/src/views/About.vue
@@ -45,14 +45,34 @@
             LUG shares an office with the UIC ACM in SELE 2264. Meetings are in SELE 2260 unless otherwise announced.
           </v-card-text>
           <v-card-actions>
-            <v-btn flat target="_blank" href="https://lugatuic.slack.com/messages" rel="noopener">
-              <v-icon left>fab fa-slack</v-icon>
-              Slack
-            </v-btn>
-            <v-btn flat target="_blank" href="https://github.com/lugatuic" rel="noopener">
-              <v-icon left>fab fa-github</v-icon>
-              Github
-            </v-btn>
+            <v-container fluid class="pa-0">
+              <v-layout row wrap>
+                <v-flex>
+                  <v-btn
+                    flat block target="_blank" rel="noopener"
+                    href="https://lugatuic.slack.com/messages">
+                    <v-icon left>fab fa-slack</v-icon>
+                    Slack
+                  </v-btn>
+                </v-flex>
+                <v-flex>
+                  <v-btn
+                    flat block target="_blank" rel="noopener"
+                    href="https://github.com/lugatuic">
+                    <v-icon left>fab fa-github</v-icon>
+                    Github
+                  </v-btn>
+                </v-flex>
+                <v-flex>
+                  <v-btn
+                    flat block target="_blank" rel="noopener"
+                    href="mailto:lug@uic.edu">
+                    <v-icon left>email</v-icon>
+                    Email
+                  </v-btn>
+                </v-flex>
+              </v-layout>
+            </v-container>
           </v-card-actions>
         </v-card>
       </v-flex>

--- a/frontend-site/src/views/About.vue
+++ b/frontend-site/src/views/About.vue
@@ -7,10 +7,17 @@
             <h1 class="title">Who We Are</h1>
           </v-card-title>
           <v-card-text>
-            who we are goes here.
+            The Linux Users Group at University of Illinois at Chicago (LUG@UIC) is a student organization whose purpose is to provide a community for students that are interested in all things related to Linux and Open Source Technology.
+            As a community we strive to provide the support and education that students seek.
+            Through various events and activities we work towards building a bigger community and spreading the use of Linux and open source software.
           </v-card-text>
           <v-card-actions>
-            <v-btn flat>Constitution</v-btn>
+            <v-btn
+            href="https://github.com/lugatuic/lug-docs/blob/master/rfc0000-lug-constitution.md"
+            flat target="_blank"
+            rel="noopener">
+              Constitution
+            </v-btn>
           </v-card-actions>
         </v-card>
       </v-flex>


### PR DESCRIPTION
Using info given by @Benbigmac , I've populated the filler fields on the about page.

Dark theme on a desktop sized screen
![lug-site-nov6-about-desktop-dark](https://user-images.githubusercontent.com/16447522/48083982-2a9f8a00-e1bc-11e8-9306-c03f9923e78c.png)

Light theme on a mobile sized screen
![lug-site-nov6-about-mobile-light](https://user-images.githubusercontent.com/16447522/48083996-3428f200-e1bc-11e8-981e-6f9e9ef884b7.png)

Still todo: Figure out what the official LUG email is.