### PR TITLE
Feature project filter sort area

### DIFF
--- a/frontend-site/package-lock.json
+++ b/frontend-site/package-lock.json
@@ -7489,8 +7489,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/frontend-site/package.json
+++ b/frontend-site/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0-rc.1",
+    "lodash": "^4.17.11",
     "vue": "^2.5.17",
     "vue-router": "^3.0.1",
     "vuetify": "^1.2.0",

--- a/frontend-site/src/components/Projects/SearchCard.vue
+++ b/frontend-site/src/components/Projects/SearchCard.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-card>
+    <v-container fluid>
+      <v-text-field
+        label="Name/Description Search"
+        persistent-hint
+        hint="## results"/>
+    </v-container>
+    <v-divider/>
+    <v-expansion-panel>
+      <v-expansion-panel-content>
+        <div slot="header">Filter</div>
+        <v-container fluid>
+          Filters content
+        </v-container>
+      </v-expansion-panel-content>
+      <v-expansion-panel-content>
+        <div slot="header">Sort</div>
+        <v-container fluid>
+          <v-layout row wrap>
+            <v-flex xs12 sm6>
+              <h2 class="subheading">Sort Type</h2>
+            </v-flex>
+            <V-flex xs12 sm6>
+              <h2 class="subheading">Sort Order</h2>
+            </V-flex>
+          </v-layout>
+        </v-container>
+      </v-expansion-panel-content>
+    </v-expansion-panel>
+  </v-card>
+</template>
+
+<script>
+export default {
+
+}
+</script>

--- a/frontend-site/src/components/Projects/SearchCard.vue
+++ b/frontend-site/src/components/Projects/SearchCard.vue
@@ -2,9 +2,10 @@
   <v-card class="project-search-card">
     <v-container fluid>
       <v-text-field
+        v-model="filterOptions.textQuery"
         label="Name/Description Search"
         persistent-hint
-        hint="## results"/>
+        :hint="resultText"/>
     </v-container>
     <v-divider/>
     <v-expansion-panel>
@@ -73,37 +74,102 @@
 
 <script>
 import * as projectValues from '@/modules/projectValues';
+import { arraysAreEquivalent } from '@/modules/utils';
+import debounce from 'lodash/debounce';
 
 export default {
+  props: {
+    allProjects: {
+      type: Array,
+      required: true,
+    },
+    value: {
+      type: Array,
+      required: true,
+    },
+  },
   computed: {
+    resultText () {
+      return `${this.value.length} ${this.value.length === 1 ? 'result' : 'results'}`;
+    },
     sortTypes: () => ['Name', 'Status', 'Date'],
     statusValues: () => projectValues.statusFilterValues,
     wikiValues: () => projectValues.wikiLinkFilterValues,
     githubValues: () => projectValues.gitHubLinkFilterValues,
+    sorts: () => ({
+      Name: (a, b, isAscending) => {
+        const result = a.name < b.name ? -1 : 1;
+        return isAscending ? result : -result;
+      },
+      // Status: (a, b, isAscending) => {
+      //   const [indexA, indexB] = [this.statusFilterValues.m]
+      // },
+    }),
+    // hasAnyFilters () {
+    //   return [
+    //     !!this.filterOptions.textQuery,
+    //     this.filterOptions.status.length !== this.statusValues,
+    //     this.filterOptions.wiki.length !== this.wikiValues,
+    //     this.filterOptions.github.length !== this.githubValues,
+    //   ].some(v => v);
+    // },
   },
   data () {
     return {
-      textQuery: '',
       sortOptions: {
         type: 'Name',
         isAscending: true,
       },
       filterOptions: {
+        textQuery: '',
         status: projectValues.statusFilterValues.map(v => v.toLowerCase()),
         wiki: projectValues.wikiLinkFilterValues.slice(),
         github: projectValues.gitHubLinkFilterValues.slice(),
       },
     };
   },
-  mounted () {
-    console.debug(this.filterOptions);
+  methods: {
+    sendNewProjectList (newList = []) {
+      this.$emit('input', newList);
+    },
+    applyFilters (input = []) {
+      return input.filter(project => {
+        const fitsTextQuery = !this.filterOptions.textQuery ||
+          (project.name && project.name.toLowerCase().includes(this.filterOptions.textQuery.toLowerCase())) ||
+          (project.description && project.description.toLowerCase().includes(this.filterOptions.textQuery.toLowerCase()));
+
+        const fitsStatus = this.filterOptions.status.includes(project.status.toLowerCase());
+
+        const fitsWiki = this.filterOptions.wiki.length === this.wikiValues.length || // all values
+          (this.filterOptions.wiki[0] === 'Has Wiki Link' && project.wikiLink) ||
+          (this.filterOptions.wiki[0] === 'Does Not Have Wiki Link' && !project.wikiLink);
+
+        const fitsGitHub = this.filterOptions.github.length === this.githubValues.length || // all values
+          (this.filterOptions.github[0] === 'Has GitHub Link' && project.githubLink) ||
+          (this.filterOptions.github[0] === 'Does Not Have GitHub Link' && !project.githubLink);
+
+        return [fitsTextQuery, fitsStatus, fitsWiki, fitsGitHub].every(v => v); // return projects that fit every filter
+      });
+    },
+    applySorts (input = []) {
+      const sortFunction = this.sorts[this.sortOptions.type] || this.sorts.Name;
+      return input.slice().sort((a, b) => sortFunction(a, b, this.sortOptions.isAscending));
+    },
+    applyOptionsAndUpdate: debounce(function () {
+      this.sendNewProjectList(this.applySorts(this.applyFilters(this.allProjects)));
+    }, 500),
   },
   watch: {
     filterOptions: {
       deep: true,
-      handler (newValue) {
-        console.debug(newValue);
+      handler () {
+        this.applyOptionsAndUpdate();
       },
+    },
+    value (newValue, oldValue) {
+      if (!arraysAreEquivalent(newValue, oldValue)) {
+        this.applyOptionsAndUpdate();
+      }
     },
   },
 };
@@ -113,6 +179,10 @@ export default {
 .project-search-card {
   .v-radio {
     flex: 1 1 auto; // even distribution of radio buttons across entire width
+  }
+
+  .v-input--checkbox .v-label {
+    text-transform: capitalize; // capitalize checkbox labels
   }
 }
 </style>

--- a/frontend-site/src/components/Projects/SearchCard.vue
+++ b/frontend-site/src/components/Projects/SearchCard.vue
@@ -92,7 +92,7 @@ export default {
     resultText () {
       return `${this.value.length} ${this.value.length === 1 ? 'result' : 'results'}`;
     },
-    sortTypes: () => ['Name', 'Status', 'Date'],
+    sortTypes: () => ['Name', 'Status', 'Start Date'],
     statusValues: () => projectValues.statusFilterValues,
     wikiValues: () => projectValues.wikiLinkFilterValues,
     githubValues: () => projectValues.gitHubLinkFilterValues,
@@ -101,18 +101,16 @@ export default {
         const result = a.name < b.name ? -1 : 1;
         return isAscending ? result : -result;
       },
-      // Status: (a, b, isAscending) => {
-      //   const [indexA, indexB] = [this.statusFilterValues.m]
-      // },
+      Status: (a, b, isAscending) => {
+        // order based on index order in values array
+        const diff = projectValues.statusFilterValues.indexOf(a.status.toLowerCase()) - projectValues.statusFilterValues.indexOf(b.status.toLowerCase());
+        return isAscending ? diff : -diff;
+      },
+      'Start Date': (a, b, isAscending) => {
+        const diff = new Date(a.startDate) - new Date(b.startDate);
+        return isAscending ? diff : -diff;
+      },
     }),
-    // hasAnyFilters () {
-    //   return [
-    //     !!this.filterOptions.textQuery,
-    //     this.filterOptions.status.length !== this.statusValues,
-    //     this.filterOptions.wiki.length !== this.wikiValues,
-    //     this.filterOptions.github.length !== this.githubValues,
-    //   ].some(v => v);
-    // },
   },
   data () {
     return {
@@ -155,7 +153,10 @@ export default {
       const sortFunction = this.sorts[this.sortOptions.type] || this.sorts.Name;
       return input.slice().sort((a, b) => sortFunction(a, b, this.sortOptions.isAscending));
     },
-    applyOptionsAndUpdate: debounce(function () {
+    applyFiltersAndUpdate: debounce(function () {
+      this.sendNewProjectList(this.applySorts(this.applyFilters(this.allProjects)));
+    }, 500),
+    applySortsAndUpdate: debounce(function () {
       this.sendNewProjectList(this.applySorts(this.applyFilters(this.allProjects)));
     }, 500),
   },
@@ -163,12 +164,18 @@ export default {
     filterOptions: {
       deep: true,
       handler () {
-        this.applyOptionsAndUpdate();
+        this.applyFiltersAndUpdate();
+      },
+    },
+    sortOptions: {
+      deep: true,
+      handler () {
+        this.applySortsAndUpdate();
       },
     },
     value (newValue, oldValue) {
       if (!arraysAreEquivalent(newValue, oldValue)) {
-        this.applyOptionsAndUpdate();
+        this.applyFiltersAndUpdate();
       }
     },
   },

--- a/frontend-site/src/components/Projects/SearchCard.vue
+++ b/frontend-site/src/components/Projects/SearchCard.vue
@@ -19,6 +19,22 @@
               <v-checkbox v-model="filterOptions.status" :label="statusValue" :value="statusValue.toLowerCase()"/>
             </v-flex>
           </v-layout>
+          <v-layout row wrap>
+            <v-flex xs12>
+              <h2 class="subheading">Wiki</h2>
+            </v-flex>
+            <v-flex v-for="(value, i) in wikiValues" :key="i">
+              <v-checkbox v-model="filterOptions.wiki" :label="value" :value="value"/>
+            </v-flex>
+          </v-layout>
+          <v-layout row wrap>
+            <v-flex xs12>
+              <h2 class="subheading">GitHub</h2>
+            </v-flex>
+            <v-flex v-for="(value, i) in githubValues" :key="i">
+              <v-checkbox v-model="filterOptions.github" :label="value" :value="value"/>
+            </v-flex>
+          </v-layout>
         </v-container>
       </v-expansion-panel-content>
       <v-expansion-panel-content>
@@ -61,7 +77,9 @@ import * as projectValues from '@/modules/projectValues';
 export default {
   computed: {
     sortTypes: () => ['Name', 'Status', 'Date'],
-    statusValues: () => projectValues.statusValues,
+    statusValues: () => projectValues.statusFilterValues,
+    wikiValues: () => projectValues.wikiLinkFilterValues,
+    githubValues: () => projectValues.gitHubLinkFilterValues,
   },
   data () {
     return {
@@ -71,7 +89,9 @@ export default {
         isAscending: true,
       },
       filterOptions: {
-        status: projectValues.statusValues.map(v => v.toLowerCase()),
+        status: projectValues.statusFilterValues.map(v => v.toLowerCase()),
+        wiki: projectValues.wikiLinkFilterValues.slice(),
+        github: projectValues.gitHubLinkFilterValues.slice(),
       },
     };
   },

--- a/frontend-site/src/components/Projects/SearchCard.vue
+++ b/frontend-site/src/components/Projects/SearchCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card>
+  <v-card class="project-search-card">
     <v-container fluid>
       <v-text-field
         label="Name/Description Search"
@@ -11,19 +11,43 @@
       <v-expansion-panel-content>
         <div slot="header">Filter</div>
         <v-container fluid>
-          Filters content
+          <v-layout row wrap>
+            <v-flex xs12>
+              <h2 class="subheading">Status</h2>
+            </v-flex>
+            <v-flex v-for="(statusValue, i) in statusValues" :key="i">
+              <v-checkbox v-model="filterOptions.status" :label="statusValue" :value="statusValue.toLowerCase()"/>
+            </v-flex>
+          </v-layout>
         </v-container>
       </v-expansion-panel-content>
       <v-expansion-panel-content>
         <div slot="header">Sort</div>
         <v-container fluid>
-          <v-layout row wrap>
-            <v-flex xs12 sm6>
+          <v-layout row>
+            <v-flex>
               <h2 class="subheading">Sort Type</h2>
+              <v-radio-group
+                v-model="sortOptions.type"
+                :row="$vuetify.breakpoint.smAndUp">
+                <v-radio
+                  v-for="(type, i) in sortTypes"
+                  :key="i"
+                  :label="type"
+                  :value="type"/>
+              </v-radio-group>
             </v-flex>
-            <V-flex xs12 sm6>
+          </v-layout>
+          <v-layout row>
+            <v-flex>
               <h2 class="subheading">Sort Order</h2>
-            </V-flex>
+              <v-radio-group
+                v-model="sortOptions.isAscending"
+                :row="$vuetify.breakpoint.smAndUp">
+                <v-radio label="Ascending" :value="true"/>
+                <v-radio label="Descending" :value="false"/>
+              </v-radio-group>
+            </v-flex>
           </v-layout>
         </v-container>
       </v-expansion-panel-content>
@@ -32,7 +56,43 @@
 </template>
 
 <script>
-export default {
+import * as projectValues from '@/modules/projectValues';
 
-}
+export default {
+  computed: {
+    sortTypes: () => ['Name', 'Status', 'Date'],
+    statusValues: () => projectValues.statusValues,
+  },
+  data () {
+    return {
+      textQuery: '',
+      sortOptions: {
+        type: 'Name',
+        isAscending: true,
+      },
+      filterOptions: {
+        status: projectValues.statusValues.map(v => v.toLowerCase()),
+      },
+    };
+  },
+  mounted () {
+    console.debug(this.filterOptions);
+  },
+  watch: {
+    filterOptions: {
+      deep: true,
+      handler (newValue) {
+        console.debug(newValue);
+      },
+    },
+  },
+};
 </script>
+
+<style lang="scss">
+.project-search-card {
+  .v-radio {
+    flex: 1 1 auto; // even distribution of radio buttons across entire width
+  }
+}
+</style>

--- a/frontend-site/src/modules/mockData.js
+++ b/frontend-site/src/modules/mockData.js
@@ -225,13 +225,33 @@ export const mockProjects = Object.freeze([
   // TODO: finalize project structure
   {
     name: 'Project Name',
-    status: 'incomplete', // use enums/predefined keys?
+    status: 'incomplete',
     description: 'project description',
-    smallImage: 'link to small image',
-    largeImage: 'link to large image',
+    smallImage: '',
+    largeImage: '',
     wikiLink: 'link to wiki for this project',
     githubLink: 'link to github for this project',
     startDate: new Date(),
+  },
+  {
+    name: 'Another Project Name',
+    status: 'abandoned',
+    description: 'abandoned project description',
+    smallImage: '',
+    largeImage: '',
+    wikiLink: '',
+    githubLink: '',
+    startDate: new Date('Oct 18 2018'),
+  },
+  {
+    name: 'Yet Another Project Name',
+    status: 'complete',
+    description: 'completed project description',
+    smallImage: '',
+    largeImage: '',
+    wikiLink: '',
+    githubLink: 'github link',
+    startDate: new Date('Nov 1 2018'),
   },
   // TODO: add mock data for website redesign project
 ]);

--- a/frontend-site/src/modules/projectValues.js
+++ b/frontend-site/src/modules/projectValues.js
@@ -1,0 +1,1 @@
+export const statusValues = Object.freeze(['Complete', 'Incomplete', 'Abandoned']);

--- a/frontend-site/src/modules/projectValues.js
+++ b/frontend-site/src/modules/projectValues.js
@@ -1,1 +1,5 @@
-export const statusValues = Object.freeze(['Complete', 'Incomplete', 'Abandoned']);
+export const statusFilterValues = Object.freeze(['Complete', 'Incomplete', 'Abandoned']);
+
+export const wikiLinkFilterValues = Object.freeze(['Has Wiki Link', 'Does Not Have Wiki Link']);
+
+export const gitHubLinkFilterValues = Object.freeze(['Has GitHub Link', 'Does Not Have GitHub Link']);

--- a/frontend-site/src/modules/projectValues.js
+++ b/frontend-site/src/modules/projectValues.js
@@ -1,4 +1,4 @@
-export const statusFilterValues = Object.freeze(['Complete', 'Incomplete', 'Abandoned']);
+export const statusFilterValues = Object.freeze(['incomplete', 'abandoned', 'complete']);
 
 export const wikiLinkFilterValues = Object.freeze(['Has Wiki Link', 'Does Not Have Wiki Link']);
 

--- a/frontend-site/src/modules/projectValues.js
+++ b/frontend-site/src/modules/projectValues.js
@@ -1,4 +1,4 @@
-export const statusFilterValues = Object.freeze(['incomplete', 'abandoned', 'complete']);
+export const statusFilterValues = Object.freeze(['complete', 'incomplete', 'abandoned']);
 
 export const wikiLinkFilterValues = Object.freeze(['Has Wiki Link', 'Does Not Have Wiki Link']);
 

--- a/frontend-site/src/modules/utils.js
+++ b/frontend-site/src/modules/utils.js
@@ -2,3 +2,9 @@ export function isDebugMode () {
   // this parameter is only defined when using the dev server from the npm run serve command
   return window.webpackHotUpdate !== undefined;
 }
+
+// check if 2 arrays have equivalent values; compareFn compares 2 items and returns true if 2 inputs are equivalent, false otherwiase
+export function arraysAreEquivalent (arr1 = [], arr2 = [], compareFn = (a, b) => a === b) {
+  return arr1.every(a => arr2.some(b => compareFn(a, b))) &&
+    arr2.every(a => arr1.some(b => compareFn(a, b)));
+}

--- a/frontend-site/src/views/Projects.vue
+++ b/frontend-site/src/views/Projects.vue
@@ -2,9 +2,7 @@
   <v-container grid-list-lg>
     <v-layout row>
       <v-flex>
-        <v-card>
-          Search area here?
-        </v-card>
+        <search-card/>
       </v-flex>
     </v-layout>
     <v-layout row wrap>
@@ -54,8 +52,12 @@
 
 <script>
 import { mockProjects } from '@/modules/mockData';
+import SearchCard from '@/components/Projects/SearchCard';
 
 export default {
+  components: {
+    SearchCard,
+  },
   computed: {
     projects: () => new Array(12).fill(mockProjects[0]),
   },

--- a/frontend-site/src/views/Projects.vue
+++ b/frontend-site/src/views/Projects.vue
@@ -2,7 +2,10 @@
   <v-container grid-list-lg>
     <v-layout row>
       <v-flex>
-        <search-card/>
+        <search-card
+          :allProjects="allProjects"
+          v-model="projects"
+        />
       </v-flex>
     </v-layout>
     <v-layout row wrap>
@@ -59,13 +62,18 @@ export default {
     SearchCard,
   },
   computed: {
-    projects: () => new Array(12).fill(mockProjects[0]),
+    // a master list of all projects
+    allProjects: () => mockProjects,
   },
   data () {
     return {
       activeProject: null,
       showModal: false,
+      projects: [],
     };
+  },
+  created () {
+    this.projects = this.allProjects.slice();
   },
   mounted () {
     console.warn('using mock data for projects');
@@ -81,6 +89,9 @@ export default {
       if (!newValue) {
         this.activeProject = null;
       }
+    },
+    allProjects (newValue) {
+      this.projects = newValue.slice();
     },
   },
 };


### PR DESCRIPTION
Work for #24. Adds a card for filtering and sorting the project listing. This also adds lodash as a dependency for debouncing, in addition to some necessary changes to other files.

Images below of the new card.

![lug-site-project-filter-filter_expanded](https://user-images.githubusercontent.com/16447522/48235618-2756fa80-e384-11e8-9bf2-483905622510.PNG)
![lug-site-project-filter-sort_expanded-light-mobile](https://user-images.githubusercontent.com/16447522/48235619-2756fa80-e384-11e8-9097-e9232e2e5e30.png)
![lug-site-project-filter-default](https://user-images.githubusercontent.com/16447522/48235620-2756fa80-e384-11e8-8f20-fe6b04f1803a.PNG)
