### PR TITLE
Fixed github link for officer cards

### DIFF
--- a/frontend-site/src/components/OfficerCard.vue
+++ b/frontend-site/src/components/OfficerCard.vue
@@ -19,7 +19,7 @@
       <v-spacer/>
       <v-btn
         v-if="officer.github"
-        :href="officer.github"
+        :href="githubLink"
         rel="noopener"
         target="_blank"
         icon>
@@ -77,6 +77,9 @@ export default {
         this.officer.term_start.replace(/_/g, ' '),
         this.officer.term_end.replace(/_/g, ' '),
       ].join('-');
+    },
+    githubLink () {
+      return `https://github.com/${this.officer.github}`;
     },
   },
 };


### PR DESCRIPTION
Before, it was assumed that the `github` field for an officer was a link to a GitHub page, but it was actually the username for an officer. This PR fixes the GitHub link on officer cards to reflect this.