### PR TITLE
Feature event card carousel UI fixes

### DIFF
--- a/frontend-site/src/App.vue
+++ b/frontend-site/src/App.vue
@@ -44,4 +44,12 @@ export default {
 html {
   overflow-y: auto;
 }
+
+.theme--dark {
+  --card-default-background-color: #424242;
+}
+
+.theme-light {
+  --card-default-background-color: #fff;
+}
 </style>

--- a/frontend-site/src/components/Home/EventCard.vue
+++ b/frontend-site/src/components/Home/EventCard.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-card :dark="!useLightTheme" :light="useLightTheme" raised class="event-card">
+  <v-card
+    :dark="!useLightTheme"
+    :light="useLightTheme"
+    raised
+    :flat="flat"
+    class="event-card">
     <v-container fluid class="pl-5 pr-5">
       <v-layout row wrap>
         <v-flex xs12 sm6>
@@ -27,6 +32,10 @@ export default {
     event: {
       type: Object,
       required: true,
+    },
+    flat: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {
@@ -61,9 +70,3 @@ export default {
   },
 };
 </script>
-
-<style>
-.event-card {
-  height: 100%;
-}
-</style>

--- a/frontend-site/src/components/Home/EventCarousel.vue
+++ b/frontend-site/src/components/Home/EventCarousel.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-carousel class="event-carousel" v-model="activeEvent" hide-delimiters>
+  <v-carousel class="event-carousel" v-model="activeEvent" hide-delimiters :cycle="false">
     <v-carousel-item v-for="(event, i) in events" :key="i">
-      <event-card :event="event"/>
+      <event-card :event="event" :flat="true"/>
     </v-carousel-item>
   </v-carousel>
 </template>
@@ -22,21 +22,47 @@ export default {
   data () {
     return {
       activeEvent: -1,
+      height: 50,
     };
   },
   methods: {
     ...mapActions('events', ['updateData']),
+    getActiveCarouselElement () {
+      // assumption: only one card is active at a time
+      return Array.from(this.$el.querySelectorAll('.v-carousel__item'))
+        .find(e => e.style.display !== 'none'); // get visible carousel item, if any
+    },
+    updateHeight () {
+      const activeElement = this.getActiveCarouselElement();
+      if (activeElement) {
+        // compare active height to stored height and update accordingly
+        const activeCard = activeElement.querySelector('.event-card');
+        const newHeight = Math.max(this.height, activeCard.offsetHeight, activeCard.clientHeight);
+        if (newHeight > this.height) {
+          this.height = newHeight;
+        }
+      }
+    },
   },
   async mounted () {
     await this.updateData();
     this.activeEvent = 0;
+  },
+  watch: {
+    height (newValue) {
+      console.debug('height changed to', newValue);
+      this.$el.style.height = `${newValue}px`;
+    },
+    activeEvent () {
+      // wait 1 tick for animation to finish
+      this.$nextTick().then(() => this.updateHeight());
+    },
   },
 };
 </script>
 
 <style lang="scss">
 .event-carousel {
-  // TODO: determine a good size, or do programmatically?
-  height: 300px;
+  background-color: var(--card-default-background-color);
 }
 </style>

--- a/frontend-site/src/components/Home/EventCarousel.vue
+++ b/frontend-site/src/components/Home/EventCarousel.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-carousel class="event-carousel" v-model="activeEvent" hide-delimiters>
+  <v-carousel
+    class="event-carousel"
+    v-model="activeEvent"
+    hide-delimiters
+    :light="useLightTheme">
     <v-carousel-item v-for="(event, i) in events" :key="i">
       <event-card :event="event" :flat="true"/>
     </v-carousel-item>
@@ -39,9 +43,14 @@ export default {
       if (activeElement) {
         // compare active height to stored height and update accordingly
         const activeCard = activeElement.querySelector('.event-card');
-        const newHeight = Math.max(this.height, activeCard.offsetHeight, activeCard.clientHeight);
+        const newHeight = Math.max(this.height, activeCard.offsetHeight);
         if (newHeight > this.height) {
           this.height = newHeight;
+        }
+
+        // update height of current card if its lesser than saved height
+        if (activeCard.offsetHeight < this.height) {
+          activeCard.style.height = `${this.height}px`;
         }
       }
     },


### PR DESCRIPTION
Work for issue #36.

Card heights are now checked every time a card in the event carousel cycles, and smaller cards have their heights changed as needed.

Icon color issues on light theme are now fixed.

**Known Issue:** Resizing to a smaller screen then to a bigger screen would result in using the taller cards from the mobile layout in the desktop layout. I think the issue is minor enough to be considered a non-issue for most cases.

![image](https://user-images.githubusercontent.com/16447522/48432658-a52b5500-e73a-11e8-8fd1-36c210b972ae.png)

![image](https://user-images.githubusercontent.com/16447522/48432796-02bfa180-e73b-11e8-9270-e779038503f7.png)

