### PR TITLE
Feature projects api frontend

### DIFF
--- a/frontend-site/src/modules/LugApi.js
+++ b/frontend-site/src/modules/LugApi.js
@@ -1,4 +1,4 @@
-import { mockOfficers, mockEvents } from '@/modules/mockData';
+import { mockOfficers, mockEvents, mockProjects } from '@/modules/mockData';
 import { isDebugMode } from '@/modules/utils';
 
 export class LugApi {
@@ -36,21 +36,25 @@ export class LugApi {
     .join('?');
   }
 
+  _defaultApiGet (baseApiUrl = '/api/someendpoint', params = {}, mockResult) {
+    const apiUrl = this._toApiUrl(baseApiUrl, params);
+    this._checkParamsForMock(params, apiUrl);
+    return !params.isMock ?
+      this._getJson(this.generateUrl(apiUrl)) :
+      Promise.resolve(mockResult);
+  }
+
   async getOfficers (params = {}) {
     // TODO: error checking for semester or leave it server side (i.e. server returns 4xx error)?
-    const apiUrl = this._toApiUrl('/api/officers', params);
-    this._checkParamsForMock(params, apiUrl);
-    return !params.isMock
-      ? this._getJson(this.generateUrl(apiUrl))
-      : Promise.resolve(mockOfficers);
+    return this._defaultApiGet('/api/officers', params, mockOfficers);
   }
 
   async getEvents (params = {}) {
-    const apiUrl = this._toApiUrl('/api/events', params);
-    this._checkParamsForMock(params, apiUrl);
-    return !params.isMock
-      ? this._getJson(this.generateUrl(apiUrl))
-      : Promise.resolve(mockEvents);
+    return this._defaultApiGet('/api/events', params, mockEvents);
+  }
+
+  async getProjects (params = {}) {
+    return this._defaultApiGet('/api/projects', params, mockProjects);
   }
 }
 

--- a/frontend-site/src/store/index.js
+++ b/frontend-site/src/store/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 import events from './events';
 import officers from './officers';
+import projects from './projects';
 
 Vue.use(Vuex);
 
@@ -9,6 +10,7 @@ export default new Vuex.Store({
   modules: {
     events,
     officers,
+    projects,
   },
   state: {
     useLightTheme: false,

--- a/frontend-site/src/store/projects.js
+++ b/frontend-site/src/store/projects.js
@@ -1,0 +1,25 @@
+import lugApi from '@/modules/LugApi';
+
+export default {
+  namespaced: true,
+  state: {
+    data: [],
+    // TODO: remove mock parameter once backend has API ready
+    useMockData: true,
+  },
+  mutations: {
+    setData (state, data) {
+      if (!Array.isArray(data)) {
+        throw new Error(`New data is not an array: ${JSON.stringify(data)}`);
+      }
+      state.data = data;
+    },
+  },
+  actions: {
+    async updateData ({ commit, state }) {
+      const data = await lugApi.getProjects({ isMock: !!state.useMockData });
+      // send data sorted by start date
+      commit('setData', data.slice());
+    },
+  },
+};

--- a/frontend-site/src/views/Projects.vue
+++ b/frontend-site/src/views/Projects.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script>
-import { mockProjects } from '@/modules/mockData';
+import { mapState, mapActions } from 'vuex';
 import SearchCard from '@/components/Projects/SearchCard';
 
 export default {
@@ -63,7 +63,12 @@ export default {
   },
   computed: {
     // a master list of all projects
-    allProjects: () => mockProjects,
+    ...mapState('projects', {
+      allProjects: 'data',
+    }),
+  },
+  methods: {
+    ...mapActions('projects', ['updateData']),
   },
   data () {
     return {
@@ -72,11 +77,8 @@ export default {
       projects: [],
     };
   },
-  created () {
-    this.projects = this.allProjects.slice();
-  },
-  mounted () {
-    console.warn('using mock data for projects');
+  async mounted () {
+    await this.updateData();
   },
   watch: {
     activeProject (newValue) {


### PR DESCRIPTION
Work for #22 . 

This PR also contains a change to how the data for other endpoints are retrieved in `frontend-site/src/modules/LugApi.js`. Mainly, I refactored the common fetch code into a `_defaultApiGet` function, as the code to get the data has been equivalent for every endpoint so far.