### PR TITLE
Enable Frontend Events Query (+ Other Small Fixes)

### DIFF
--- a/frontend-site/.gitignore
+++ b/frontend-site/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+package-lock.json
 
 # local env files
 .env.local

--- a/frontend-site/package.json
+++ b/frontend-site/package.json
@@ -12,7 +12,7 @@
     "lodash": "^4.17.11",
     "vue": "^2.5.17",
     "vue-router": "^3.0.1",
-    "vuetify": "^1.2.0",
+    "vuetify": "1.2.0",
     "vuex": "^3.0.1"
   },
   "devDependencies": {

--- a/frontend-site/src/App.vue
+++ b/frontend-site/src/App.vue
@@ -26,7 +26,7 @@ export default {
   },
   data () {
     return {
-      showNavDrawer: false,
+      showNavDrawer: true,
     };
   },
 };

--- a/frontend-site/src/App.vue
+++ b/frontend-site/src/App.vue
@@ -26,7 +26,7 @@ export default {
   },
   data () {
     return {
-      showNavDrawer: true,
+      showNavDrawer: false,
     };
   },
 };

--- a/frontend-site/src/components/Home/EventCarousel.vue
+++ b/frontend-site/src/components/Home/EventCarousel.vue
@@ -72,7 +72,6 @@ export default {
   },
   watch: {
     height (newValue) {
-      console.warn(newValue);
       this.$el.style.height = `${newValue}px`;
     },
     activeEvent () {

--- a/frontend-site/src/components/Home/EventCarousel.vue
+++ b/frontend-site/src/components/Home/EventCarousel.vue
@@ -3,6 +3,7 @@
     class="event-carousel"
     v-model="activeEvent"
     hide-delimiters
+    :interval="5000"
     :light="useLightTheme">
     <v-carousel-item v-for="(event, i) in events" :key="i">
       <event-card :event="event" :flat="true"/>
@@ -23,12 +24,14 @@ export default {
     ...mapState('events', {
       events: 'data',
     }),
+    defaultCardHeight: () => 100,
   },
   data () {
     return {
       activeEvent: -1,
-      height: 50,
-      onAnimationEndHandler: null,
+      height: 100,
+      debouncedUpdateHeight: null,
+      cardHeights: new Map(),
     };
   },
   methods: {
@@ -43,8 +46,13 @@ export default {
       if (activeElement) {
         // compare active height to stored height and update accordingly
         const activeCard = activeElement.querySelector('.event-card');
-        const newHeight = Math.max(this.height, activeCard.offsetHeight);
-        if (newHeight > this.height) {
+
+        // only set card height for valid events
+        if (this.events[this.activeEvent]) {
+          this.cardHeights.set(this.events[this.activeEvent], activeCard.offsetHeight);
+        }
+        const newHeight = Math.max(this.defaultCardHeight, ...Array.from(this.cardHeights.values()));
+        if (newHeight !== this.height) {
           this.height = newHeight;
         }
 
@@ -59,25 +67,16 @@ export default {
     await this.updateData();
     this.activeEvent = 0;
 
-    // shared instance for EH removal in beforeDestroy
     // debounced in case multiple EH fire simultaneously
-    this.onAnimationEndHandler = debounce(() => this.updateHeight(), 50);
-
-    // add event handler for after transitions finish to ensure only one card is visible when updating height
-    Array.from(this.$el.querySelectorAll('.v-carousel__item')).forEach(item => {
-      item.addEventListener('transitionend', this.onAnimationEndHandler);
-      item.addEventListener('webkitTransitionEnd', this.onAnimationEndHandler);
-    });
-  },
-  beforeDestroy () {
-    Array.from(this.$el.querySelectorAll('.v-carousel__item')).forEach(item => {
-      item.removeEventListener('transitionend', this.onAnimationEndHandler);
-      item.removeEventListener('webkitTransitionEnd', this.onAnimationEndHandler);
-    });
+    this.debouncedUpdateHeight = debounce(() => this.updateHeight(), 1000);
   },
   watch: {
     height (newValue) {
+      console.warn(newValue);
       this.$el.style.height = `${newValue}px`;
+    },
+    activeEvent () {
+      this.debouncedUpdateHeight();
     },
   },
 };
@@ -87,5 +86,6 @@ export default {
 .event-carousel {
   background-color: var(--card-default-background-color);
   height: 150px; // default
+  transition: height 0.5s;
 }
 </style>

--- a/frontend-site/src/components/Home/UtilitiesListing.vue
+++ b/frontend-site/src/components/Home/UtilitiesListing.vue
@@ -28,7 +28,11 @@ export default {
 </script>
 
 <style lang="scss">
-.utility-listing .utility-card {
-  min-height: 100px;
+.utility-listing {
+  justify-content: center;
+
+  .utility-card {
+    min-height: 100px;
+  }
 }
 </style>

--- a/frontend-site/src/components/MainNavigationDrawer.vue
+++ b/frontend-site/src/components/MainNavigationDrawer.vue
@@ -3,7 +3,7 @@
     persistent
     :width="200"
     :value="value"
-    @input="$emit('input', $event)"
+    @input="emitValue($event)"
     enable-resize-watcher
     fixed app>
     <v-container fluid class="pl-0 pr-0 pt-0">
@@ -18,7 +18,7 @@
           <!-- list of site links -->
           <v-list>
             <template v-for="(item, i) in pages">
-              <v-list-tile v-if="item.to || item.href" :key="i" :to="item.to" :href="item.href">
+              <v-list-tile v-if="item.to || item.href" :key="i" :to="item.to" :href="item.href" @click="emitValue(false)">
                 <v-list-tile-content>
                   <v-list-tile-title>{{ item.name }}</v-list-tile-title>
                 </v-list-tile-content>
@@ -84,6 +84,18 @@ export default {
         to: '/about',
       },
     ],
+  },
+  async mounted () {
+    // hide on load if nav drawer can be toggled
+    if (this.$vuetify.breakpoint.mdAndDown) {
+      await this.$nextTick();
+      this.emitValue(false);
+    }
+  },
+  methods: {
+    emitValue (newValue) {
+      this.$emit('input', newValue);
+    },
   },
 };
 </script>

--- a/frontend-site/src/components/MainNavigationDrawer.vue
+++ b/frontend-site/src/components/MainNavigationDrawer.vue
@@ -93,8 +93,11 @@ export default {
     }
   },
   methods: {
-    emitValue (newValue) {
-      this.$emit('input', newValue);
+    emitValue (newValue, forceSend = false) {
+      // only send if nav drawer can be toggled by default; otherwise breaks on large displays
+      if (this.$vuetify.breakpoint.mdAndDown || forceSend) {
+        this.$emit('input', newValue);
+      }
     },
   },
 };

--- a/frontend-site/src/store/events.js
+++ b/frontend-site/src/store/events.js
@@ -4,8 +4,7 @@ export default {
   namespaced: true,
   state: {
     data: [],
-    // TODO: remove mock parameter once backend has API ready
-    useMockData: true,
+    useMockData: false,
   },
   mutations: {
     setData (state, data) {

--- a/frontend-site/src/views/Projects.vue
+++ b/frontend-site/src/views/Projects.vue
@@ -14,11 +14,10 @@
         :key="i"
         xs12 md6 lg3>
         <!-- TODO: refactor into separate component -->
-        <v-card @click.native="activeProject = project" class="project-card">
-          <!-- would put v-img or other image element here -->
-          <v-container style="border: 1px solid white;">
-
-              <v-img :src="project.smallImage"></v-img>
+        <v-card @click.native="activeProject = project" class="project-card" :dark="!useLightTheme">
+          <!-- only show image if it exists -->
+          <v-container v-if="project.smallImage" style="border: 1px solid lightslategrey;">
+            <v-img :src="project.smallImage"></v-img>
           </v-container>
           <v-card-title primary-title>
             <h1 class="headline">{{ project.name }}</h1>
@@ -30,7 +29,7 @@
       </v-flex>
     </v-layout>
     <v-dialog v-model="showModal">
-      <v-card v-if="activeProject">
+      <v-card v-if="activeProject" :dark="!useLightTheme">
         <v-card-text>
           <v-container fluid>
             <v-layout row wrap>
@@ -68,6 +67,7 @@ export default {
     ...mapState('projects', {
       allProjects: 'data',
     }),
+    ...mapState(['useLightTheme']),
   },
   methods: {
     ...mapActions('projects', ['updateData']),
@@ -104,6 +104,12 @@ export default {
 <style lang="scss">
 .project-card {
   cursor: pointer;
+
+  &:hover {
+    border: 1px solid lightslategrey;
+    margin: -1px;
+  }
+
   & > * {
     pointer-events: none;
   }

--- a/frontend-site/src/views/Services.vue
+++ b/frontend-site/src/views/Services.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container grid-list-lg>
     <v-layout row wrap>
-      <v-flex xs12 sm6 md4 v-for="(service, i) in services" :key="i">
+      <v-flex xs12 sm6 v-for="(service, i) in services" :key="i">
         <v-card class="ma-2">
           <v-container fluid class="pa-0">
              <v-layout row align-center>


### PR DESCRIPTION
Mainly work for #9, but also has a number of small fixes that will go into #65.

* Hide nav drawer on load
* Enable calling of events endpoint from the frontend.
* Fixed bug where events card didn't resize properly (mix of library update breaking something and Chrome deprecating something)
* Fixed image loading bug in project card, added hover effect when mousing over project card
* Limit services listing to 2 columns
* Align utility items center

No GIF this time; you'll need to build it locally to see the changes to the UI.